### PR TITLE
Add in-memory NoSQL core with indexing and versioning

### DIFF
--- a/src/main/java/rs/clustiqdb/index/IndexManager.java
+++ b/src/main/java/rs/clustiqdb/index/IndexManager.java
@@ -1,0 +1,69 @@
+package rs.clustiqdb.index;
+
+import rs.clustiqdb.store.Entity;
+
+import java.util.*;
+
+/**
+ * Maintains simple in-memory indexes for entity fields.
+ */
+public class IndexManager {
+    private final Map<String, NavigableMap<Comparable, Set<String>>> indexes = new HashMap<>();
+
+    public void index(Entity entity) {
+        String id = entity.getId();
+        for (Map.Entry<String, Object> e : entity.getFields().entrySet()) {
+            Object value = e.getValue();
+            if (value instanceof Comparable) {
+                NavigableMap<Comparable, Set<String>> map = indexes.computeIfAbsent(e.getKey(), k -> new TreeMap<>());
+                Set<String> ids = map.computeIfAbsent((Comparable) value, v -> new HashSet<>());
+                ids.add(id);
+            }
+        }
+    }
+
+    public void remove(Entity entity) {
+        String id = entity.getId();
+        for (Map.Entry<String, Object> e : entity.getFields().entrySet()) {
+            Object value = e.getValue();
+            if (value instanceof Comparable) {
+                NavigableMap<Comparable, Set<String>> map = indexes.get(e.getKey());
+                if (map != null) {
+                    Set<String> ids = map.get((Comparable) value);
+                    if (ids != null) {
+                        ids.remove(id);
+                        if (ids.isEmpty()) {
+                            map.remove((Comparable) value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public Set<String> searchEquals(String field, Comparable value) {
+        NavigableMap<Comparable, Set<String>> map = indexes.get(field);
+        if (map == null) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(map.getOrDefault(value, Collections.emptySet()));
+    }
+
+    public Set<String> searchGreaterThan(String field, Comparable value) {
+        NavigableMap<Comparable, Set<String>> map = indexes.get(field);
+        if (map == null) {
+            return Collections.emptySet();
+        }
+        return map.tailMap(value, false).values().stream()
+                .collect(HashSet::new, Set::addAll, Set::addAll);
+    }
+
+    public Set<String> searchLessThan(String field, Comparable value) {
+        NavigableMap<Comparable, Set<String>> map = indexes.get(field);
+        if (map == null) {
+            return Collections.emptySet();
+        }
+        return map.headMap(value, false).values().stream()
+                .collect(HashSet::new, Set::addAll, Set::addAll);
+    }
+}

--- a/src/main/java/rs/clustiqdb/pipeline/Pipeline.java
+++ b/src/main/java/rs/clustiqdb/pipeline/Pipeline.java
@@ -1,0 +1,41 @@
+package rs.clustiqdb.pipeline;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * Simple pipeline system that supports filter/map/group/reduce operations
+ * on collections of data.
+ */
+public class Pipeline<T> {
+    private final Stream<T> stream;
+
+    public Pipeline(Collection<T> source) {
+        this.stream = source.stream();
+    }
+
+    private Pipeline(Stream<T> stream) {
+        this.stream = stream;
+    }
+
+    public Pipeline<T> filter(Predicate<T> predicate) {
+        return new Pipeline<>(stream.filter(predicate));
+    }
+
+    public <R> Pipeline<R> map(Function<T, R> mapper) {
+        return new Pipeline<>(stream.map(mapper));
+    }
+
+    public <K> Map<K, List<T>> groupBy(Function<T, K> classifier) {
+        return stream.collect(Collectors.groupingBy(classifier));
+    }
+
+    public <R> R reduce(R identity, BiFunction<R, T, R> accumulator, BinaryOperator<R> combiner) {
+        return stream.reduce(identity, accumulator, combiner);
+    }
+
+    public List<T> toList() {
+        return stream.collect(Collectors.toList());
+    }
+}

--- a/src/main/java/rs/clustiqdb/query/QueryExpression.java
+++ b/src/main/java/rs/clustiqdb/query/QueryExpression.java
@@ -1,0 +1,72 @@
+package rs.clustiqdb.query;
+
+import rs.clustiqdb.index.IndexManager;
+import rs.clustiqdb.store.DocumentStore;
+
+import java.util.*;
+
+/**
+ * Functional interface representing a query expression that can
+ * evaluate itself using indexes and the document store.
+ */
+public interface QueryExpression {
+    Set<String> evaluate(IndexManager indexes, DocumentStore store);
+
+    enum Operator { EQ, GT, LT }
+
+    static QueryExpression field(String field, Operator op, Comparable value) {
+        return (indexes, store) -> {
+            switch (op) {
+                case EQ:
+                    return indexes.searchEquals(field, value);
+                case GT:
+                    return indexes.searchGreaterThan(field, value);
+                case LT:
+                    return indexes.searchLessThan(field, value);
+                default:
+                    return Collections.emptySet();
+            }
+        };
+    }
+
+    static QueryExpression contains(String field, String substring) {
+        return (indexes, store) -> {
+            Set<String> result = new HashSet<>();
+            for (var entity : store.findAll()) {
+                Object v = entity.get(field);
+                if (v instanceof String && ((String) v).contains(substring)) {
+                    result.add(entity.getId());
+                }
+            }
+            return result;
+        };
+    }
+
+    static QueryExpression and(QueryExpression... exprs) {
+        return (indexes, store) -> {
+            if (exprs.length == 0) {
+                return Collections.emptySet();
+            }
+            Set<String> result = null;
+            for (QueryExpression e : exprs) {
+                Set<String> set = e.evaluate(indexes, store);
+                if (result == null) {
+                    result = new HashSet<>(set);
+                } else {
+                    result.retainAll(set);
+                }
+            }
+            return result == null ? Collections.emptySet() : result;
+        };
+    }
+
+    static QueryExpression or(QueryExpression... exprs) {
+        return (indexes, store) -> {
+            Set<String> result = new HashSet<>();
+            for (QueryExpression e : exprs) {
+                result.addAll(e.evaluate(indexes, store));
+            }
+            return result;
+        };
+    }
+}

--- a/src/main/java/rs/clustiqdb/store/DocumentStore.java
+++ b/src/main/java/rs/clustiqdb/store/DocumentStore.java
@@ -1,0 +1,61 @@
+package rs.clustiqdb.store;
+
+import rs.clustiqdb.index.IndexManager;
+import rs.clustiqdb.query.QueryExpression;
+import rs.clustiqdb.version.VersioningManager;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory store for schemaless entities with automatic indexing
+ * and simple versioning support.
+ */
+public class DocumentStore {
+    private final Map<String, Entity> data = new HashMap<>();
+    private final IndexManager indexManager = new IndexManager();
+    private final VersioningManager versioningManager = new VersioningManager();
+
+    public void insert(Entity entity) {
+        data.put(entity.getId(), entity);
+        indexManager.index(entity);
+        versioningManager.recordInsert(entity);
+    }
+
+    public void update(String id, Map<String, Object> newFields) {
+        Entity old = data.get(id);
+        if (old != null) {
+            indexManager.remove(old);
+        }
+        Entity entity = new Entity(id, newFields);
+        data.put(id, entity);
+        indexManager.index(entity);
+        versioningManager.recordUpdate(id, newFields);
+    }
+
+    public void delete(String id) {
+        Entity entity = data.remove(id);
+        if (entity != null) {
+            indexManager.remove(entity);
+            versioningManager.recordDelete(id);
+        }
+    }
+
+    public List<Entity> query(QueryExpression expr) {
+        Set<String> ids = expr.evaluate(indexManager, this);
+        return ids.stream().map(data::get).collect(Collectors.toList());
+    }
+
+    public Collection<Entity> findAll() {
+        return data.values();
+    }
+
+    public Entity get(String id) {
+        return data.get(id);
+    }
+
+    public Entity getAt(String id, long timestamp) {
+        Map<String, Object> fields = versioningManager.getAt(id, timestamp);
+        return fields == null ? null : new Entity(id, fields);
+    }
+}

--- a/src/main/java/rs/clustiqdb/store/Entity.java
+++ b/src/main/java/rs/clustiqdb/store/Entity.java
@@ -1,0 +1,28 @@
+package rs.clustiqdb.store;
+
+import java.util.Map;
+
+/**
+ * Represents a single schemaless entity stored in the database.
+ */
+public class Entity {
+    private final String id;
+    private final Map<String, Object> fields;
+
+    public Entity(String id, Map<String, Object> fields) {
+        this.id = id;
+        this.fields = fields;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Object get(String field) {
+        return fields.get(field);
+    }
+
+    public Map<String, Object> getFields() {
+        return fields;
+    }
+}

--- a/src/main/java/rs/clustiqdb/version/VersioningManager.java
+++ b/src/main/java/rs/clustiqdb/version/VersioningManager.java
@@ -1,0 +1,52 @@
+package rs.clustiqdb.version;
+
+import rs.clustiqdb.store.Entity;
+
+import java.util.*;
+
+/**
+ * Maintains simple time-travel history for entities.
+ */
+public class VersioningManager {
+    private static class Version {
+        final long timestamp;
+        final Map<String, Object> fields;
+        Version(long timestamp, Map<String, Object> fields) {
+            this.timestamp = timestamp;
+            this.fields = new HashMap<>(fields);
+        }
+    }
+
+    private final Map<String, List<Version>> history = new HashMap<>();
+
+    public void recordInsert(Entity entity) {
+        history.computeIfAbsent(entity.getId(), k -> new ArrayList<>())
+                .add(new Version(System.currentTimeMillis(), entity.getFields()));
+    }
+
+    public void recordUpdate(String id, Map<String, Object> fields) {
+        history.computeIfAbsent(id, k -> new ArrayList<>())
+                .add(new Version(System.currentTimeMillis(), fields));
+    }
+
+    public void recordDelete(String id) {
+        history.computeIfAbsent(id, k -> new ArrayList<>())
+                .add(new Version(System.currentTimeMillis(), Collections.emptyMap()));
+    }
+
+    public Map<String, Object> getAt(String id, long timestamp) {
+        List<Version> versions = history.get(id);
+        if (versions == null) {
+            return null;
+        }
+        Version result = null;
+        for (Version v : versions) {
+            if (v.timestamp <= timestamp) {
+                result = v;
+            } else {
+                break;
+            }
+        }
+        return result == null ? null : new HashMap<>(result.fields);
+    }
+}

--- a/src/test/java/rs/clustiqdb/DocumentStoreTest.java
+++ b/src/test/java/rs/clustiqdb/DocumentStoreTest.java
@@ -1,0 +1,41 @@
+package rs.clustiqdb;
+
+import org.junit.jupiter.api.Test;
+import rs.clustiqdb.store.DocumentStore;
+import rs.clustiqdb.store.Entity;
+import rs.clustiqdb.query.QueryExpression;
+import rs.clustiqdb.pipeline.Pipeline;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DocumentStoreTest {
+    @Test
+    public void testStoreQueryPipelineAndVersioning() throws InterruptedException {
+        DocumentStore store = new DocumentStore();
+        store.insert(new Entity("1", Map.of("age", 30, "name", "Alice")));
+        store.insert(new Entity("2", Map.of("age", 25, "name", "Bob")));
+        store.insert(new Entity("3", Map.of("age", 40, "name", "Carol")));
+
+        List<Entity> olderThan29 = store.query(QueryExpression.field("age", QueryExpression.Operator.GT, 29));
+        assertEquals(2, olderThan29.size());
+
+        List<Entity> bob = store.query(QueryExpression.and(
+                QueryExpression.field("age", QueryExpression.Operator.LT, 35),
+                QueryExpression.contains("name", "o")));
+        assertEquals(1, bob.size());
+        assertEquals("Bob", bob.get(0).get("name"));
+
+        Pipeline<Entity> pipeline = new Pipeline<>(store.findAll());
+        Map<Object, List<Entity>> grouped = pipeline.groupBy(e -> e.get("age"));
+        assertEquals(3, grouped.size());
+
+        long timestamp = System.currentTimeMillis();
+        Thread.sleep(1); // ensure timestamp difference
+        store.update("1", Map.of("age", 31, "name", "Alice"));
+        Entity previous = store.getAt("1", timestamp);
+        assertNotNull(previous);
+        assertEquals(30, previous.get("age"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement schemaless `Entity` storage with automatic indexing and version history
- Provide a query API with logical operators, comparisons and substring matching
- Introduce a simple pipeline for filter, map, group and reduce operations

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68962bfaaf94832d8d2b1a589e70c8f7