### PR TITLE
Add advanced CLI operations and value expression parsing

### DIFF
--- a/src/main/java/com/crux/cli/CommandLine.java
+++ b/src/main/java/com/crux/cli/CommandLine.java
@@ -1,6 +1,7 @@
 package com.crux.cli;
 
 import com.crux.query.FilterParser;
+import com.crux.query.FilterParser.ValueExpression;
 import com.crux.query.QueryExpression;
 import com.crux.store.DocumentStore;
 import com.crux.store.Entity;
@@ -18,6 +19,12 @@ public class CommandLine {
     private final DocumentStore store = new DocumentStore();
     private final FilterParser parser = new FilterParser();
     private final Gson gson = new Gson();
+    private final Map<String, Set<String>> sets = new HashMap<>();
+    private Map<String, ValueExpression> transformFunction = new HashMap<>();
+
+    public CommandLine() {
+        sets.put("all", new HashSet<>());
+    }
 
     public void run() {
         Scanner sc = new Scanner(System.in);
@@ -39,6 +46,7 @@ public class CommandLine {
         } else if (line.startsWith("delete entity")) {
             String id = line.substring("delete entity".length()).trim();
             store.delete(id);
+            for (Set<String> s : sets.values()) s.remove(id);
             System.out.println("deleted " + id);
         } else if (line.startsWith("update entities where")) {
             updateEntities(line);
@@ -51,6 +59,14 @@ public class CommandLine {
             getField(line);
         } else if (line.startsWith("get some")) {
             getSome(line);
+        } else if (line.startsWith("generate")) {
+            generate(line);
+        } else if (line.startsWith("find similar")) {
+            findSimilar(line);
+        } else if (line.startsWith("create transform function")) {
+            createTransformFunction(line);
+        } else if (line.startsWith("apply transform function")) {
+            applyTransformFunction(line);
         } else if (line.equalsIgnoreCase("help")) {
             printHelp();
         } else if (line.startsWith("show history")) {
@@ -80,6 +96,7 @@ public class CommandLine {
         String id = (String) map.getOrDefault("id", UUID.randomUUID().toString());
         map.put("id", id);
         store.insert(new Entity(id, map));
+        sets.get("all").add(id);
         System.out.println("inserted " + id);
     }
 
@@ -134,6 +151,81 @@ public class CommandLine {
         System.out.println(gson.toJson(result));
     }
 
+    private void generate(String line) {
+        int n = Integer.parseInt(line.substring("generate".length()).trim());
+        Random rnd = new Random();
+        for (int i = 0; i < n; i++) {
+            Map<String,Object> m = new HashMap<>();
+            String id = UUID.randomUUID().toString();
+            m.put("id", id);
+            m.put("value", rnd.nextInt(1000));
+            List<Double> vec = new ArrayList<>();
+            for (int j = 0; j < 3; j++) vec.add(rnd.nextDouble());
+            m.put("vector", vec);
+            store.insert(new Entity(id, m));
+            sets.get("all").add(id);
+        }
+        System.out.println("generated " + n);
+    }
+
+    private void findSimilar(String line) {
+        String rest = line.substring("find similar".length()).trim();
+        String[] parts = rest.split("\\s+");
+        String id = parts[0];
+        int top = parts.length > 1 ? Integer.parseInt(parts[1]) : 5;
+        List<Entity> res = store.findSimilar(id, top);
+        System.out.println(gson.toJson(res.stream().map(Entity::getFields).collect(Collectors.toList())));
+    }
+
+    private void createTransformFunction(String line) {
+        int lb = line.indexOf('{');
+        int rb = line.lastIndexOf('}');
+        if (lb == -1 || rb == -1 || rb < lb) throw new IllegalArgumentException("missing body");
+        String body = line.substring(lb+1, rb).trim();
+        transformFunction = new HashMap<>();
+        for (String part : body.split("[;\n]")) {
+            part = part.trim();
+            if (part.isEmpty()) continue;
+            int arrow = part.indexOf("->");
+            if (arrow == -1) continue;
+            String exprStr = part.substring(0, arrow).trim();
+            String field = part.substring(arrow+2).trim();
+            ValueExpression ve = parser.parseValueExpression(exprStr);
+            transformFunction.put(field, ve);
+        }
+        System.out.println("transform function created");
+    }
+
+    private void applyTransformFunction(String line) {
+        String lower = line.toLowerCase(Locale.ROOT);
+        int fromIdx = lower.indexOf("from set");
+        if (fromIdx == -1) throw new IllegalArgumentException("missing from set");
+        fromIdx += "from set".length();
+        int toIdx = lower.indexOf("to", fromIdx);
+        if (toIdx == -1) throw new IllegalArgumentException("missing to");
+        String setName = line.substring(fromIdx, toIdx).trim();
+        String newSet = line.substring(toIdx + 2).trim();
+        Set<String> ids = sets.getOrDefault(setName, Collections.emptySet());
+        Set<String> target = sets.computeIfAbsent(newSet, k -> new HashSet<>());
+        int count = 0;
+        for (String id : ids) {
+            Entity e = store.get(id);
+            if (e == null) continue;
+            Map<String,Object> nf = new HashMap<>();
+            for (var entry : transformFunction.entrySet()) {
+                Object val = entry.getValue().eval(e);
+                putFieldValue(nf, entry.getKey(), val);
+            }
+            String nid = UUID.randomUUID().toString();
+            nf.put("id", nid);
+            store.insert(new Entity(nid, nf));
+            sets.get("all").add(nid);
+            target.add(nid);
+            count++;
+        }
+        System.out.println("transformed " + count);
+    }
+
     private Object getFieldValue(Entity e, String path) {
         String[] parts = path.split("\\.");
         Object current = e.getFields();
@@ -148,6 +240,15 @@ public class CommandLine {
         return current;
     }
 
+    private void putFieldValue(Map<String,Object> map, String path, Object value) {
+        String[] parts = path.split("\\.");
+        Map<String,Object> current = map;
+        for (int i = 0; i < parts.length-1; i++) {
+            current = (Map<String,Object>) current.computeIfAbsent(parts[i], k -> new HashMap<>());
+        }
+        current.put(parts[parts.length-1], value);
+    }
+
     private void printHelp() {
         System.out.println("Available commands:");
         System.out.println(" add entity {json} [vector [n1 n2 ...]]");
@@ -156,7 +257,11 @@ public class CommandLine {
         System.out.println(" get entities using filter <filter>");
         System.out.println(" get field <path> from <id>");
         System.out.println(" get some [N]");
+        System.out.println(" generate N");
+        System.out.println(" find similar <id> [N]");
         System.out.println(" show history <id>");
+        System.out.println(" create transform function { expr -> field }");
+        System.out.println(" apply transform function from set <src> to <dest>");
         System.out.println(" help");
         System.out.println(" exit");
     }

--- a/src/main/java/com/crux/query/FilterParser.java
+++ b/src/main/java/com/crux/query/FilterParser.java
@@ -20,7 +20,7 @@ public class FilterParser {
 
         boolean hasNext() { skipWs(); return pos < s.length(); }
 
-        String peek() { int p = pos; return next(); }
+        String peek() { int p = pos; String t = next(); pos = p; return t; }
 
         String next() {
             skipWs();
@@ -71,6 +71,12 @@ public class FilterParser {
     public QueryExpression parse(String input) {
         Lexer lexer = new Lexer(input);
         return parseOr(lexer);
+    }
+
+    /** Parses a standalone value expression. */
+    public ValueExpression parseValueExpression(String input) {
+        Lexer lexer = new Lexer(input);
+        return parseValueExpr(lexer);
     }
 
     private QueryExpression parseOr(Lexer l) {

--- a/src/test/java/com/crux/FilterParserTest.java
+++ b/src/test/java/com/crux/FilterParserTest.java
@@ -1,0 +1,24 @@
+package com.crux;
+
+import com.crux.query.FilterParser;
+import com.crux.store.DocumentStore;
+import com.crux.store.Entity;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FilterParserTest {
+    @Test
+    public void testNumericComparison() {
+        DocumentStore store = new DocumentStore();
+        store.insert(new Entity("1", Map.of("age", 30)));
+        store.insert(new Entity("2", Map.of("age", 25)));
+        FilterParser parser = new FilterParser();
+        var expr = parser.parse("age >= 30");
+        var res = store.query(expr);
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+    }
+}


### PR DESCRIPTION
## Summary
- expand CLI with entity sets, random generation, similarity search, and transform functions
- implement cosine-similarity lookup in DocumentStore
- expose value-expression parsing and fix lexer peek bug
- add regression test for numeric filter expression

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689667bff8ac832dab47bccd85b858c5