### PR TITLE
feat: auto-detect literal types

### DIFF
--- a/src/main/java/com/crux/query/FilterParser.java
+++ b/src/main/java/com/crux/query/FilterParser.java
@@ -282,8 +282,12 @@ public class FilterParser {
         if ("true".equalsIgnoreCase(t) || "false".equalsIgnoreCase(t)) {
             return ValueExpression.literal(Boolean.parseBoolean(t));
         }
-        // number
-        return ValueExpression.literal(Double.parseDouble(t));
+        // attempt numeric parsing, otherwise treat as string
+        try {
+            return ValueExpression.literal(Double.parseDouble(t));
+        } catch (NumberFormatException ex) {
+            return ValueExpression.literal(t);
+        }
     }
 
     private Object getFieldValue(Entity e, String path) {

--- a/src/test/java/com/crux/FilterParserTest.java
+++ b/src/test/java/com/crux/FilterParserTest.java
@@ -21,4 +21,28 @@ public class FilterParserTest {
         assertEquals(1, res.size());
         assertEquals("1", res.get(0).getId());
     }
+
+    @Test
+    public void testBooleanComparison() {
+        DocumentStore store = new DocumentStore();
+        store.insert(new Entity("1", Map.of("flag", true)));
+        store.insert(new Entity("2", Map.of("flag", false)));
+        FilterParser parser = new FilterParser();
+        var expr = parser.parse("flag == true");
+        var res = store.query(expr);
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+    }
+
+    @Test
+    public void testStringComparison() {
+        DocumentStore store = new DocumentStore();
+        store.insert(new Entity("1", Map.of("name", "alice")));
+        store.insert(new Entity("2", Map.of("name", "bob")));
+        FilterParser parser = new FilterParser();
+        var expr = parser.parse("name == alice");
+        var res = store.query(expr);
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+    }
 }


### PR DESCRIPTION
## Summary
- auto-detect numeric, boolean, or string literals in query values
- add tests for boolean and string comparisons

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6897430eddb0832d8dd8bad70ca77e48