### PR TITLE
Support equality alias and complex filter expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Once started you can interact with the store using the commands below. Type
 Filters use the syntax `<field> <operator> <value expression>`. Value
 expressions may contain numbers, strings, booleans or references to other
 fields using the `&fieldName` notation. The supported comparison operators are
-`==`, `!=`, `>`, `>=`, `<` and `<=`.
+`==`, `!=`, `>`, `>=`, `<`, `<=` and `=` (alias for equality).
 
 Examples:
 

--- a/src/main/java/com/crux/query/FilterParser.java
+++ b/src/main/java/com/crux/query/FilterParser.java
@@ -189,6 +189,7 @@ public class FilterParser {
     }
 
     private boolean compare(Object l, Object r, String op) {
+        if ("=".equals(op)) op = "==";
         if (l == null || r == null) {
             return "==".equals(op) ? Objects.equals(l,r) : "!=".equals(op) && !Objects.equals(l,r);
         }

--- a/src/test/java/com/crux/FilterParserTest.java
+++ b/src/test/java/com/crux/FilterParserTest.java
@@ -40,7 +40,19 @@ public class FilterParserTest {
         store.insert(new Entity("1", Map.of("name", "alice")));
         store.insert(new Entity("2", Map.of("name", "bob")));
         FilterParser parser = new FilterParser();
-        var expr = parser.parse("name == alice");
+        var expr = parser.parse("name == \"alice\"");
+        var res = store.query(expr);
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+    }
+
+    @Test
+    public void testComplexExpression() {
+        DocumentStore store = new DocumentStore();
+        store.insert(new Entity("1", Map.of("feature", Map.of("tag", 4), "id", 150)));
+        store.insert(new Entity("2", Map.of("feature", Map.of("tag", 5), "id", 187)));
+        FilterParser parser = new FilterParser();
+        var expr = parser.parse("id = (25 * &feature.tag/2) * 3");
         var res = store.query(expr);
         assertEquals(1, res.size());
         assertEquals("1", res.get(0).getId());


### PR DESCRIPTION
## Summary
- Interpret single `=` as an equality operator in filter comparisons
- Require quoted strings in tests and exercise complex arithmetic filter expressions
- Document `=` as an equality alias in README

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6897505430dc832da14c5f9794a78051