### PR TITLE
Add persistence and query enhancements to in-memory store

### DIFF
--- a/src/main/java/com/crux/cli/CommandLine.java
+++ b/src/main/java/com/crux/cli/CommandLine.java
@@ -27,7 +27,7 @@ public class CommandLine {
     Map<String, ValueExpression> transformFunction = new HashMap<>();
 
     public CommandLine() {
-        sets.put("all", new HashSet<>());
+        sets.put("all", new HashSet<>(store.getAllIds()));
     }
 
     public void run() {
@@ -239,6 +239,16 @@ public class CommandLine {
         }
     }
 
+    void persistSnapshot() {
+        try {
+            store.saveSnapshot();
+            System.out.println("snapshot saved");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to persist snapshot", e);
+            throw new RuntimeException(e);
+        }
+    }
+
     Object getFieldValue(Entity e, String path) {
         String[] parts = path.split("\\.");
         Object current = e.getFields();
@@ -275,6 +285,7 @@ public class CommandLine {
         System.out.println(" show history <id>");
         System.out.println(" create transform function { expr -> field }");
         System.out.println(" apply transform function from set <src> to <dest>");
+        System.out.println(" persist snapshot");
         System.out.println(" help");
         System.out.println(" exit");
     }

--- a/src/main/java/com/crux/cli/CommandParser.java
+++ b/src/main/java/com/crux/cli/CommandParser.java
@@ -93,6 +93,7 @@ public class CommandParser {
             case "create" -> parseCreate(t);
             case "apply" -> parseApply(t);
             case "show" -> parseShow(t);
+            case "persist" -> parsePersist(t);
             case "help" -> cli -> cli.printHelp();
             default -> throw new RuntimeException("unknown command");
         };
@@ -240,5 +241,13 @@ public class CommandParser {
             return cli -> System.out.println(cli.gson.toJson(cli.store.getHistory(id)));
         }
         throw new RuntimeException("unknown show command");
+    }
+
+    private Command parsePersist(Tokenizer t) {
+        String second = t.next();
+        if ("snapshot".equalsIgnoreCase(second)) {
+            return CommandLine::persistSnapshot;
+        }
+        throw new RuntimeException("unknown persist command");
     }
 }

--- a/src/main/java/com/crux/index/IndexManager.java
+++ b/src/main/java/com/crux/index/IndexManager.java
@@ -3,8 +3,10 @@ package com.crux.index;
 import com.crux.store.Entity;
 
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * Maintains simple in-memory indexes for entity fields.
@@ -13,6 +15,7 @@ public class IndexManager {
     private static final Logger LOGGER = Logger.getLogger(IndexManager.class.getName());
 
     private final Map<String, NavigableMap<Comparable, Set<String>>> indexes = new HashMap<>();
+    private final Map<String, Map<String, String>> textValues = new HashMap<>();
 
     public void index(Entity entity) {
         if (entity == null) {
@@ -21,14 +24,7 @@ public class IndexManager {
         }
         try {
             String id = entity.getId();
-            for (Map.Entry<String, Object> e : entity.getFields().entrySet()) {
-                Object value = e.getValue();
-                if (value instanceof Comparable) {
-                    NavigableMap<Comparable, Set<String>> map = indexes.computeIfAbsent(e.getKey(), k -> new TreeMap<>());
-                    Set<String> ids = map.computeIfAbsent((Comparable) value, v -> new HashSet<>());
-                    ids.add(id);
-                }
-            }
+            entity.getFields().forEach((key, value) -> traverse(key, value, (path, val) -> addValue(path, val, id)));
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "Failed to index entity", ex);
         }
@@ -41,21 +37,7 @@ public class IndexManager {
         }
         try {
             String id = entity.getId();
-            for (Map.Entry<String, Object> e : entity.getFields().entrySet()) {
-                Object value = e.getValue();
-                if (value instanceof Comparable) {
-                    NavigableMap<Comparable, Set<String>> map = indexes.get(e.getKey());
-                    if (map != null) {
-                        Set<String> ids = map.get((Comparable) value);
-                        if (ids != null) {
-                            ids.remove(id);
-                            if (ids.isEmpty()) {
-                                map.remove((Comparable) value);
-                            }
-                        }
-                    }
-                }
-            }
+            entity.getFields().forEach((key, value) -> traverse(key, value, (path, val) -> removeValue(path, val, id)));
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "Failed to remove entity from index", ex);
         }
@@ -66,11 +48,15 @@ public class IndexManager {
             LOGGER.warning("searchEquals called with null field or value");
             return Collections.emptySet();
         }
+        Comparable<?> normalized = normalizeComparable(value);
+        if (normalized == null) {
+            return Collections.emptySet();
+        }
         NavigableMap<Comparable, Set<String>> map = indexes.get(field);
         if (map == null) {
             return Collections.emptySet();
         }
-        return new HashSet<>(map.getOrDefault(value, Collections.emptySet()));
+        return new HashSet<>(map.getOrDefault(normalized, Collections.emptySet()));
     }
 
     public Set<String> searchGreaterThan(String field, Comparable value) {
@@ -78,11 +64,15 @@ public class IndexManager {
             LOGGER.warning("searchGreaterThan called with null field or value");
             return Collections.emptySet();
         }
+        Comparable<?> normalized = normalizeComparable(value);
+        if (normalized == null) {
+            return Collections.emptySet();
+        }
         NavigableMap<Comparable, Set<String>> map = indexes.get(field);
         if (map == null) {
             return Collections.emptySet();
         }
-        return map.tailMap(value, false).values().stream()
+        return map.tailMap(normalized, false).values().stream()
                 .collect(HashSet::new, Set::addAll, Set::addAll);
     }
 
@@ -91,11 +81,189 @@ public class IndexManager {
             LOGGER.warning("searchLessThan called with null field or value");
             return Collections.emptySet();
         }
+        Comparable<?> normalized = normalizeComparable(value);
+        if (normalized == null) {
+            return Collections.emptySet();
+        }
         NavigableMap<Comparable, Set<String>> map = indexes.get(field);
         if (map == null) {
             return Collections.emptySet();
         }
-        return map.headMap(value, false).values().stream()
+        return map.headMap(normalized, false).values().stream()
                 .collect(HashSet::new, Set::addAll, Set::addAll);
+    }
+
+    public Set<String> searchGreaterOrEquals(String field, Comparable value) {
+        if (field == null || value == null) {
+            LOGGER.warning("searchGreaterOrEquals called with null field or value");
+            return Collections.emptySet();
+        }
+        Comparable<?> normalized = normalizeComparable(value);
+        if (normalized == null) {
+            return Collections.emptySet();
+        }
+        NavigableMap<Comparable, Set<String>> map = indexes.get(field);
+        if (map == null) {
+            return Collections.emptySet();
+        }
+        return map.tailMap(normalized, true).values().stream()
+                .collect(HashSet::new, Set::addAll, Set::addAll);
+    }
+
+    public Set<String> searchLessOrEquals(String field, Comparable value) {
+        if (field == null || value == null) {
+            LOGGER.warning("searchLessOrEquals called with null field or value");
+            return Collections.emptySet();
+        }
+        Comparable<?> normalized = normalizeComparable(value);
+        if (normalized == null) {
+            return Collections.emptySet();
+        }
+        NavigableMap<Comparable, Set<String>> map = indexes.get(field);
+        if (map == null) {
+            return Collections.emptySet();
+        }
+        return map.headMap(normalized, true).values().stream()
+                .collect(HashSet::new, Set::addAll, Set::addAll);
+    }
+
+    public Set<String> searchContains(String field, String substring) {
+        if (field == null || substring == null) {
+            LOGGER.warning("searchContains called with null arguments");
+            return Collections.emptySet();
+        }
+        Map<String, String> values = textValues.get(field);
+        if (values == null) {
+            return Collections.emptySet();
+        }
+        String needle = substring.toLowerCase(Locale.ROOT);
+        Set<String> result = new HashSet<>();
+        for (var entry : values.entrySet()) {
+            if (entry.getValue().contains(needle)) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    public Set<String> searchLike(String field, String pattern) {
+        if (field == null || pattern == null) {
+            LOGGER.warning("searchLike called with null arguments");
+            return Collections.emptySet();
+        }
+        Map<String, String> values = textValues.get(field);
+        if (values == null) {
+            return Collections.emptySet();
+        }
+        Pattern regex = Pattern.compile(convertLikePattern(pattern.toLowerCase(Locale.ROOT)));
+        Set<String> result = new HashSet<>();
+        for (var entry : values.entrySet()) {
+            if (regex.matcher(entry.getValue()).matches()) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    private void addValue(String path, Object value, String id) {
+        if (value == null || path == null) {
+            return;
+        }
+        Comparable<?> comparable = normalizeComparable(value);
+        if (comparable != null) {
+            NavigableMap<Comparable, Set<String>> map = indexes.computeIfAbsent(path, k -> new TreeMap<>());
+            Set<String> ids = map.computeIfAbsent(comparable, v -> new HashSet<>());
+            ids.add(id);
+        }
+        if (value instanceof String str) {
+            textValues.computeIfAbsent(path, k -> new HashMap<>()).put(id, str.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private void removeValue(String path, Object value, String id) {
+        if (value == null || path == null) {
+            return;
+        }
+        Comparable<?> comparable = normalizeComparable(value);
+        if (comparable != null) {
+            NavigableMap<Comparable, Set<String>> map = indexes.get(path);
+            if (map != null) {
+                Set<String> ids = map.get(comparable);
+                if (ids != null) {
+                    ids.remove(id);
+                    if (ids.isEmpty()) {
+                        map.remove(comparable);
+                    }
+                }
+                if (map.isEmpty()) {
+                    indexes.remove(path);
+                }
+            }
+        }
+        if (value instanceof String) {
+            Map<String, String> values = textValues.get(path);
+            if (values != null) {
+                values.remove(id);
+                if (values.isEmpty()) {
+                    textValues.remove(path);
+                }
+            }
+        }
+    }
+
+    private void traverse(String path, Object value, BiConsumer<String, Object> consumer) {
+        if (value instanceof Map<?,?> map) {
+            for (var entry : map.entrySet()) {
+                Object key = entry.getKey();
+                if (key == null) continue;
+                String child = path == null ? key.toString() : path + "." + key;
+                traverse(child, entry.getValue(), consumer);
+            }
+        } else if (value instanceof List<?> list) {
+            for (int i = 0; i < list.size(); i++) {
+                String child = path == null ? Integer.toString(i) : path + "." + i;
+                traverse(child, list.get(i), consumer);
+            }
+        } else {
+            consumer.accept(path, value);
+        }
+    }
+
+    private String convertLikePattern(String pattern) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('^');
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            switch (c) {
+                case '%':
+                    sb.append(".*");
+                    break;
+                case '_':
+                    sb.append('.');
+                    break;
+                case '\\':
+                    if (i + 1 < pattern.length()) {
+                        sb.append(Pattern.quote(String.valueOf(pattern.charAt(++i))));
+                    }
+                    break;
+                default:
+                    if (".[]{}()*+-?^$|".indexOf(c) >= 0) {
+                        sb.append('\\');
+                    }
+                    sb.append(c);
+            }
+        }
+        sb.append('$');
+        return sb.toString();
+    }
+
+    private Comparable<?> normalizeComparable(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof Comparable<?> comparable) {
+            return comparable;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/crux/persistence/PersistenceManager.java
+++ b/src/main/java/com/crux/persistence/PersistenceManager.java
@@ -1,0 +1,187 @@
+package com.crux.persistence;
+
+import com.crux.store.Entity;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.util.*;
+
+/**
+ * Handles persistence of the in-memory store using snapshot and WAL files.
+ */
+public class PersistenceManager {
+    private static final Type SNAPSHOT_TYPE = new TypeToken<Map<String, Map<String, Object>>>() {}.getType();
+
+    private final Path baseDirectory;
+    private final Path snapshotPath;
+    private final Path walPath;
+    private final Gson gson = new GsonBuilder().create();
+
+    public PersistenceManager(Path baseDirectory) {
+        this.baseDirectory = baseDirectory;
+        this.snapshotPath = baseDirectory.resolve("snapshot.json");
+        this.walPath = baseDirectory.resolve("wal.log");
+        try {
+            Files.createDirectories(baseDirectory);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create persistence directory", e);
+        }
+    }
+
+    public LoadedState load() {
+        Map<String, Map<String, Object>> data = new LinkedHashMap<>();
+        List<LogEntry> history = new ArrayList<>();
+        long snapshotTimestamp = 0L;
+        try {
+            if (Files.exists(snapshotPath)) {
+                snapshotTimestamp = Files.getLastModifiedTime(snapshotPath).toMillis();
+                try (Reader reader = Files.newBufferedReader(snapshotPath, StandardCharsets.UTF_8)) {
+                    Map<String, Map<String, Object>> snapshot = gson.fromJson(reader, SNAPSHOT_TYPE);
+                    if (snapshot != null) {
+                        for (var entry : snapshot.entrySet()) {
+                            Map<String, Object> copy = deepCopy(entry.getValue());
+                            data.put(entry.getKey(), copy);
+                            history.add(new LogEntry(Operation.INSERT, entry.getKey(), deepCopy(copy), snapshotTimestamp));
+                        }
+                    }
+                }
+            }
+            if (Files.exists(walPath)) {
+                try (BufferedReader reader = Files.newBufferedReader(walPath, StandardCharsets.UTF_8)) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        if (line.isBlank()) {
+                            continue;
+                        }
+                        WalEntry entry = gson.fromJson(line, WalEntry.class);
+                        if (entry == null || entry.id == null || entry.operation == null) {
+                            continue;
+                        }
+                        Map<String, Object> copy = entry.fields == null ? null : deepCopy(entry.fields);
+                        apply(data, entry.operation, entry.id, copy);
+                        history.add(new LogEntry(entry.operation, entry.id, copy, entry.timestamp));
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load persisted state", e);
+        }
+        history.sort(Comparator.comparingLong(LogEntry::timestamp));
+        return new LoadedState(data, history);
+    }
+
+    public void appendInsert(Entity entity) throws IOException {
+        Map<String, Object> copy = deepCopy(entity.getFields());
+        append(new LogEntry(Operation.INSERT, entity.getId(), copy, System.currentTimeMillis()));
+    }
+
+    public void appendUpdate(String id, Map<String, Object> fields) throws IOException {
+        append(new LogEntry(Operation.UPDATE, id, deepCopy(fields), System.currentTimeMillis()));
+    }
+
+    public void appendDelete(String id) throws IOException {
+        append(new LogEntry(Operation.DELETE, id, null, System.currentTimeMillis()));
+    }
+
+    public void saveSnapshot(Collection<Entity> entities) throws IOException {
+        Map<String, Map<String, Object>> snapshot = new LinkedHashMap<>();
+        for (Entity entity : entities) {
+            snapshot.put(entity.getId(), deepCopy(entity.getFields()));
+        }
+        Files.createDirectories(baseDirectory);
+        Path tmp = baseDirectory.resolve("snapshot.tmp");
+        try (Writer writer = Files.newBufferedWriter(tmp, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            gson.toJson(snapshot, writer);
+        }
+        try {
+            Files.move(tmp, snapshotPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException ex) {
+            Files.move(tmp, snapshotPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+        Files.deleteIfExists(walPath);
+        try {
+            Files.setLastModifiedTime(snapshotPath, FileTime.fromMillis(System.currentTimeMillis()));
+        } catch (IOException ignored) {
+        }
+    }
+
+    private void append(LogEntry entry) throws IOException {
+        WalEntry walEntry = new WalEntry(entry.operation(), entry.id(), entry.fields() == null ? null : deepCopy(entry.fields()), entry.timestamp());
+        String json = gson.toJson(walEntry);
+        Files.writeString(walPath, json + System.lineSeparator(), StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    private void apply(Map<String, Map<String, Object>> data, Operation op, String id, Map<String, Object> fields) {
+        switch (op) {
+            case INSERT, UPDATE -> {
+                if (fields != null) {
+                    data.put(id, deepCopy(fields));
+                }
+            }
+            case DELETE -> data.remove(id);
+        }
+    }
+
+    private Map<String, Object> deepCopy(Map<String, Object> source) {
+        Map<String, Object> copy = new LinkedHashMap<>();
+        for (var entry : source.entrySet()) {
+            copy.put(entry.getKey(), deepCopyValue(entry.getValue()));
+        }
+        return copy;
+    }
+
+    private Object deepCopyValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> nested = new LinkedHashMap<>();
+            for (var entry : map.entrySet()) {
+                nested.put(String.valueOf(entry.getKey()), deepCopyValue(entry.getValue()));
+            }
+            return nested;
+        }
+        if (value instanceof List<?> list) {
+            List<Object> nested = new ArrayList<>();
+            for (Object o : list) {
+                nested.add(deepCopyValue(o));
+            }
+            return nested;
+        }
+        return value;
+    }
+
+    public record LoadedState(Map<String, Map<String, Object>> data, List<LogEntry> history) {}
+
+    public record LogEntry(Operation operation, String id, Map<String, Object> fields, long timestamp) {}
+
+    public enum Operation { INSERT, UPDATE, DELETE }
+
+    private static final class WalEntry {
+        Operation operation;
+        String id;
+        Map<String, Object> fields;
+        long timestamp;
+
+        WalEntry() {
+        }
+
+        WalEntry(Operation operation, String id, Map<String, Object> fields, long timestamp) {
+            this.operation = operation;
+            this.id = id;
+            this.fields = fields;
+            this.timestamp = timestamp;
+        }
+    }
+}
+

--- a/src/main/java/com/crux/pipeline/Pipeline.java
+++ b/src/main/java/com/crux/pipeline/Pipeline.java
@@ -35,6 +35,14 @@ public class Pipeline<T> {
         return stream.reduce(identity, accumulator, combiner);
     }
 
+    public double sum(ToDoubleFunction<T> mapper) {
+        return stream.mapToDouble(mapper).sum();
+    }
+
+    public double average(ToDoubleFunction<T> mapper) {
+        return stream.mapToDouble(mapper).average().orElse(0d);
+    }
+
     public List<T> toList() {
         return stream.collect(Collectors.toList());
     }

--- a/src/main/java/com/crux/query/QueryExpression.java
+++ b/src/main/java/com/crux/query/QueryExpression.java
@@ -2,8 +2,10 @@ package com.crux.query;
 
 import com.crux.index.IndexManager;
 import com.crux.store.DocumentStore;
+import com.crux.store.Entity;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * Functional interface representing a query expression that can
@@ -12,34 +14,59 @@ import java.util.*;
 public interface QueryExpression {
     Set<String> evaluate(IndexManager indexes, DocumentStore store);
 
-    enum Operator { EQ, GT, LT }
+    enum Operator {
+        EQ("=="),
+        NE("!="),
+        GT(">"),
+        GTE(">="),
+        LT("<"),
+        LTE("<=");
+
+        private final String symbol;
+
+        Operator(String symbol) {
+            this.symbol = symbol;
+        }
+
+        public String symbol() {
+            return symbol;
+        }
+
+        public static Optional<Operator> fromSymbol(String symbol) {
+            for (Operator op : values()) {
+                if (op.symbol.equals(symbol)) {
+                    return Optional.of(op);
+                }
+            }
+            return Optional.empty();
+        }
+    }
 
     static QueryExpression field(String field, Operator op, Comparable value) {
         return (indexes, store) -> {
-            switch (op) {
-                case EQ:
-                    return indexes.searchEquals(field, value);
-                case GT:
-                    return indexes.searchGreaterThan(field, value);
-                case LT:
-                    return indexes.searchLessThan(field, value);
-                default:
-                    return Collections.emptySet();
-            }
+            return switch (op) {
+                case EQ -> indexes.searchEquals(field, value);
+                case GT -> indexes.searchGreaterThan(field, value);
+                case GTE -> indexes.searchGreaterOrEquals(field, value);
+                case LT -> indexes.searchLessThan(field, value);
+                case LTE -> indexes.searchLessOrEquals(field, value);
+                case NE -> {
+                    Set<String> all = new HashSet<>(store.getAllIds());
+                    all.removeAll(indexes.searchEquals(field, value));
+                    yield all;
+                }
+            };
         };
     }
 
     static QueryExpression contains(String field, String substring) {
         return (indexes, store) -> {
-            Set<String> result = new HashSet<>();
-            for (var entity : store.findAll()) {
-                Object v = entity.get(field);
-                if (v instanceof String && ((String) v).contains(substring)) {
-                    result.add(entity.getId());
-                }
-            }
-            return result;
+            return indexes.searchContains(field, substring);
         };
+    }
+
+    static QueryExpression like(String field, String pattern) {
+        return (indexes, store) -> indexes.searchLike(field, pattern);
     }
 
     static QueryExpression and(QueryExpression... exprs) {
@@ -65,6 +92,26 @@ public interface QueryExpression {
             Set<String> result = new HashSet<>();
             for (QueryExpression e : exprs) {
                 result.addAll(e.evaluate(indexes, store));
+            }
+            return result;
+        };
+    }
+
+    static QueryExpression not(QueryExpression expr) {
+        return (indexes, store) -> {
+            Set<String> all = new HashSet<>(store.getAllIds());
+            all.removeAll(expr.evaluate(indexes, store));
+            return all;
+        };
+    }
+
+    static QueryExpression fromPredicate(Predicate<Entity> predicate) {
+        return (indexes, store) -> {
+            Set<String> result = new HashSet<>();
+            for (Entity entity : store.findAll()) {
+                if (predicate.test(entity)) {
+                    result.add(entity.getId());
+                }
             }
             return result;
         };

--- a/src/main/java/com/crux/store/Entity.java
+++ b/src/main/java/com/crux/store/Entity.java
@@ -1,5 +1,7 @@
 package com.crux.store;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -11,7 +13,7 @@ public class Entity {
 
     public Entity(String id, Map<String, Object> fields) {
         this.id = id;
-        this.fields = fields;
+        this.fields = Collections.unmodifiableMap(new LinkedHashMap<>(fields));
     }
 
     public String getId() {

--- a/src/main/java/com/crux/version/VersioningManager.java
+++ b/src/main/java/com/crux/version/VersioningManager.java
@@ -1,5 +1,6 @@
 package com.crux.version;
 
+import com.crux.persistence.PersistenceManager;
 import com.crux.store.Entity;
 
 import java.util.*;
@@ -12,12 +13,13 @@ import java.util.logging.Logger;
 public class VersioningManager {
     private static final Logger LOGGER = Logger.getLogger(VersioningManager.class.getName());
 
-    private record Version(long timestamp, Map<String, Object> fields) {
-            private Version(long timestamp, Map<String, Object> fields) {
-                this.timestamp = timestamp;
-                this.fields = new HashMap<>(fields);
-            }
+    private record Version(long timestamp, Map<String, Object> fields, boolean deleted) {
+        private Version(long timestamp, Map<String, Object> fields, boolean deleted) {
+            this.timestamp = timestamp;
+            this.fields = fields == null ? null : deepCopy(fields);
+            this.deleted = deleted;
         }
+    }
 
     private final Map<String, List<Version>> history = new HashMap<>();
 
@@ -27,8 +29,7 @@ public class VersioningManager {
             return;
         }
         try {
-            history.computeIfAbsent(entity.getId(), k -> new ArrayList<>())
-                    .add(new Version(System.currentTimeMillis(), entity.getFields()));
+            addVersion(entity.getId(), new Version(System.currentTimeMillis(), entity.getFields(), false));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to record insert", e);
         }
@@ -40,8 +41,7 @@ public class VersioningManager {
             return;
         }
         try {
-            history.computeIfAbsent(id, k -> new ArrayList<>())
-                    .add(new Version(System.currentTimeMillis(), fields));
+            addVersion(id, new Version(System.currentTimeMillis(), fields, false));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to record update for id " + id, e);
         }
@@ -53,8 +53,7 @@ public class VersioningManager {
             return;
         }
         try {
-            history.computeIfAbsent(id, k -> new ArrayList<>())
-                    .add(new Version(System.currentTimeMillis(), Collections.emptyMap()));
+            addVersion(id, new Version(System.currentTimeMillis(), null, true));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to record delete for id " + id, e);
         }
@@ -78,7 +77,10 @@ public class VersioningManager {
                     break;
                 }
             }
-            return result == null ? null : new HashMap<>(result.fields);
+            if (result == null || result.deleted) {
+                return null;
+            }
+            return deepCopy(result.fields);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to get version at time for id " + id, e);
             return null;
@@ -94,12 +96,84 @@ public class VersioningManager {
             List<Version> versions = history.getOrDefault(id, Collections.emptyList());
             List<Map<String, Object>> out = new ArrayList<>();
             for (Version v : versions) {
-                out.add(new HashMap<>(v.fields));
+                Map<String, Object> snapshot = v.fields == null ? new LinkedHashMap<>() : deepCopy(v.fields);
+                snapshot.put("_timestamp", v.timestamp);
+                snapshot.put("_deleted", v.deleted);
+                out.add(snapshot);
             }
             return out;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to get history for id " + id, e);
             return Collections.emptyList();
         }
+    }
+
+    public Map<String, Map<String, Object>> snapshotAt(long timestamp) {
+        Map<String, Map<String, Object>> snapshot = new LinkedHashMap<>();
+        for (String id : history.keySet()) {
+            Map<String, Object> state = getAt(id, timestamp);
+            if (state != null) {
+                snapshot.put(id, state);
+            }
+        }
+        return snapshot;
+    }
+
+    public void bootstrap(Collection<PersistenceManager.LogEntry> entries) {
+        history.clear();
+        if (entries == null) {
+            return;
+        }
+        List<PersistenceManager.LogEntry> ordered = new ArrayList<>(entries);
+        ordered.sort(Comparator.comparingLong(PersistenceManager.LogEntry::timestamp));
+        for (PersistenceManager.LogEntry entry : ordered) {
+            PersistenceManager.Operation op = entry.operation();
+            if (op == null || entry.id() == null) {
+                continue;
+            }
+            switch (op) {
+                case INSERT, UPDATE -> addVersion(entry.id(), new Version(entry.timestamp(), entry.fields(), false));
+                case DELETE -> addVersion(entry.id(), new Version(entry.timestamp(), null, true));
+            }
+        }
+    }
+
+    private void addVersion(String id, Version version) {
+        if (id == null || version == null) {
+            return;
+        }
+        List<Version> versions = history.computeIfAbsent(id, k -> new ArrayList<>());
+        if (!versions.isEmpty() && versions.get(versions.size() - 1).timestamp <= version.timestamp) {
+            versions.add(version);
+        } else {
+            versions.add(version);
+            versions.sort(Comparator.comparingLong(Version::timestamp));
+        }
+    }
+
+    private static Map<String, Object> deepCopy(Map<String, Object> source) {
+        Map<String, Object> copy = new LinkedHashMap<>();
+        for (var entry : source.entrySet()) {
+            copy.put(entry.getKey(), deepCopyValue(entry.getValue()));
+        }
+        return copy;
+    }
+
+    private static Object deepCopyValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> nested = new LinkedHashMap<>();
+            for (var entry : map.entrySet()) {
+                nested.put(String.valueOf(entry.getKey()), deepCopyValue(entry.getValue()));
+            }
+            return nested;
+        }
+        if (value instanceof List<?> list) {
+            List<Object> nested = new ArrayList<>();
+            for (Object o : list) {
+                nested.add(deepCopyValue(o));
+            }
+            return nested;
+        }
+        return value;
     }
 }

--- a/src/test/java/com/crux/DocumentStoreTest.java
+++ b/src/test/java/com/crux/DocumentStoreTest.java
@@ -1,41 +1,74 @@
 package com.crux;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import com.crux.store.DocumentStore;
 import com.crux.store.Entity;
 import com.crux.query.QueryExpression;
 import com.crux.pipeline.Pipeline;
 
 import java.util.*;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentStoreTest {
     @Test
-    public void testStoreQueryPipelineAndVersioning() throws InterruptedException {
-        DocumentStore store = new DocumentStore();
-        store.insert(new Entity("1", Map.of("age", 30, "name", "Alice")));
+    public void testStoreQueryPipelineAndVersioning(@TempDir Path tempDir) throws InterruptedException {
+        DocumentStore store = new DocumentStore(tempDir);
+        store.insert(new Entity("1", Map.of(
+                "age", 30,
+                "name", "Alice",
+                "address", Map.of("city", "Belgrade"))));
         store.insert(new Entity("2", Map.of("age", 25, "name", "Bob")));
         store.insert(new Entity("3", Map.of("age", 40, "name", "Carol")));
 
         List<Entity> olderThan29 = store.query(QueryExpression.field("age", QueryExpression.Operator.GT, 29));
         assertEquals(2, olderThan29.size());
 
+        List<Entity> belgrade = store.query(QueryExpression.field("address.city", QueryExpression.Operator.EQ, "Belgrade"));
+        assertEquals(1, belgrade.size());
+
         List<Entity> bob = store.query(QueryExpression.and(
-                QueryExpression.field("age", QueryExpression.Operator.LT, 35),
-                QueryExpression.contains("name", "o")));
+                QueryExpression.field("age", QueryExpression.Operator.LTE, 35),
+                QueryExpression.contains("name", "O")));
         assertEquals(1, bob.size());
         assertEquals("Bob", bob.get(0).get("name"));
 
         Pipeline<Entity> pipeline = new Pipeline<>(store.findAll());
-        Map<Object, List<Entity>> grouped = pipeline.groupBy(e -> e.get("age"));
-        assertEquals(3, grouped.size());
+        double averageAge = pipeline.average(e -> ((Number) e.get("age")).doubleValue());
+        assertEquals((30 + 25 + 40) / 3.0, averageAge, 1e-6);
 
         long timestamp = System.currentTimeMillis();
-        Thread.sleep(1); // ensure timestamp difference
-        store.update("1", Map.of("age", 31, "name", "Alice"));
+        Thread.sleep(5); // ensure timestamp difference
+        store.updatePartial("1", Map.of("age", 31, "nickname", "Ace"));
+
         Entity previous = store.getAt("1", timestamp);
         assertNotNull(previous);
-        assertEquals(30, previous.get("age"));
+        assertEquals(30.0, ((Number) previous.get("age")).doubleValue());
+        assertNull(previous.get("nickname"));
+
+        List<Entity> snapshot = store.snapshotAt(timestamp);
+        assertEquals(3, snapshot.size());
+        Optional<Entity> originalAlice = snapshot.stream().filter(e -> e.getId().equals("1")).findFirst();
+        assertTrue(originalAlice.isPresent());
+        assertEquals(30.0, ((Number) originalAlice.get().get("age")).doubleValue());
+
+        store.delete("2");
+        List<Map<String, Object>> history = store.getHistory("2");
+        assertFalse(history.isEmpty());
+        assertEquals(Boolean.TRUE, history.get(history.size() - 1).get("_deleted"));
+
+        store.saveSnapshot();
+        DocumentStore reloaded = new DocumentStore(tempDir);
+        assertNull(reloaded.get("2"));
+        assertEquals(2, reloaded.findAll().size());
+
+        long reloadTimestamp = System.currentTimeMillis();
+        Thread.sleep(5);
+        reloaded.update("1", Map.of("age", 33, "name", "Alice"));
+        DocumentStore reloadedAgain = new DocumentStore(tempDir);
+        assertEquals(33.0, ((Number) reloadedAgain.get("1").get("age")).doubleValue());
+        assertNotNull(reloadedAgain.getAt("1", reloadTimestamp));
     }
 }

--- a/src/test/java/com/crux/FilterParserTest.java
+++ b/src/test/java/com/crux/FilterParserTest.java
@@ -4,15 +4,17 @@ import com.crux.query.FilterParser;
 import com.crux.store.DocumentStore;
 import com.crux.store.Entity;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class FilterParserTest {
     @Test
-    public void testNumericComparison() {
-        DocumentStore store = new DocumentStore();
+    public void testNumericComparison(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
         store.insert(new Entity("1", Map.of("age", 30)));
         store.insert(new Entity("2", Map.of("age", 25)));
         FilterParser parser = new FilterParser();
@@ -23,8 +25,8 @@ public class FilterParserTest {
     }
 
     @Test
-    public void testBooleanComparison() {
-        DocumentStore store = new DocumentStore();
+    public void testBooleanComparison(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
         store.insert(new Entity("1", Map.of("flag", true)));
         store.insert(new Entity("2", Map.of("flag", false)));
         FilterParser parser = new FilterParser();
@@ -35,8 +37,8 @@ public class FilterParserTest {
     }
 
     @Test
-    public void testStringComparison() {
-        DocumentStore store = new DocumentStore();
+    public void testStringComparison(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
         store.insert(new Entity("1", Map.of("name", "alice")));
         store.insert(new Entity("2", Map.of("name", "bob")));
         FilterParser parser = new FilterParser();
@@ -47,12 +49,41 @@ public class FilterParserTest {
     }
 
     @Test
-    public void testComplexExpression() {
-        DocumentStore store = new DocumentStore();
+    public void testComplexExpression(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
         store.insert(new Entity("1", Map.of("feature", Map.of("tag", 4), "id", 150)));
         store.insert(new Entity("2", Map.of("feature", Map.of("tag", 5), "id", 187)));
         FilterParser parser = new FilterParser();
         var expr = parser.parse("id = (25 * &feature.tag/2) * 3");
+        var res = store.query(expr);
+        assertEquals(1, res.size());
+        assertEquals("1", res.get(0).getId());
+    }
+
+    @Test
+    public void testContainsAndLike(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
+        store.insert(new Entity("1", Map.of("title", "Data Engineering")));
+        store.insert(new Entity("2", Map.of("title", "Data Science")));
+        FilterParser parser = new FilterParser();
+        var contains = parser.parse("title contains \"engine\"");
+        var resContains = store.query(contains);
+        assertEquals(1, resContains.size());
+        assertEquals("1", resContains.get(0).getId());
+
+        var like = parser.parse("title like \"Data%Science\"");
+        var resLike = store.query(like);
+        assertEquals(1, resLike.size());
+        assertEquals("2", resLike.get(0).getId());
+    }
+
+    @Test
+    public void testNotOperator(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
+        store.insert(new Entity("1", Map.of("age", 30)));
+        store.insert(new Entity("2", Map.of("age", 20)));
+        FilterParser parser = new FilterParser();
+        var expr = parser.parse("not age < 25");
         var res = store.query(expr);
         assertEquals(1, res.size());
         assertEquals("1", res.get(0).getId());


### PR DESCRIPTION
## Summary
- integrate a persistence layer with snapshot and WAL support for the document store and maintain version history for time-travel queries
- extend indexing and filter parsing to cover dot-path fields, additional comparison operators, and text contains/like searches
- expose the new capabilities through CLI commands, aggregation helpers, and expanded regression tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68d948fc80f0832d914594b44423c570