### PR TITLE
Handle hyphenated identifiers in filters

### DIFF
--- a/src/main/java/com/crux/query/FilterParser.java
+++ b/src/main/java/com/crux/query/FilterParser.java
@@ -30,15 +30,25 @@ public class FilterParser {
             skipWs();
             if (pos >= s.length()) return null;
             char c = s.charAt(pos);
-            if (Character.isLetter(c) || c == '_' ) {
+            if (Character.isLetter(c) || Character.isDigit(c) || c == '_' ) {
                 int start = pos;
-                while (pos < s.length() &&
-                        (Character.isLetterOrDigit(s.charAt(pos)) || s.charAt(pos)=='_' || s.charAt(pos)=='.')) pos++;
-                return s.substring(start, pos);
-            }
-            if (Character.isDigit(c)) {
-                int start = pos;
-                while (pos < s.length() && (Character.isDigit(s.charAt(pos)) || s.charAt(pos)=='.')) pos++;
+                boolean sawLetter = Character.isLetter(c) || c == '_';
+                pos++;
+                while (pos < s.length()) {
+                    char ch = s.charAt(pos);
+                    if (Character.isLetterOrDigit(ch) || ch == '_' || ch == '.') {
+                        if (Character.isLetter(ch) || ch == '_') {
+                            sawLetter = true;
+                        }
+                        pos++;
+                        continue;
+                    }
+                    if (ch == '-' && sawLetter && pos + 1 < s.length() && Character.isLetterOrDigit(s.charAt(pos + 1))) {
+                        pos++;
+                        continue;
+                    }
+                    break;
+                }
                 return s.substring(start, pos);
             }
             if (c == '"' || c=='\'') {

--- a/src/test/java/com/crux/FilterParserTest.java
+++ b/src/test/java/com/crux/FilterParserTest.java
@@ -88,4 +88,16 @@ public class FilterParserTest {
         assertEquals(1, res.size());
         assertEquals("1", res.get(0).getId());
     }
+
+    @Test
+    public void testHyphenatedIdentifierWithoutQuotes(@TempDir Path tempDir) {
+        DocumentStore store = new DocumentStore(tempDir);
+        String uuid = "e1395e90-4773-4089-a1bb-5362f2ff79da";
+        store.insert(new Entity(uuid, Map.of("id", uuid)));
+        FilterParser parser = new FilterParser();
+        var expr = parser.parse("id == " + uuid);
+        var res = store.query(expr);
+        assertEquals(1, res.size());
+        assertEquals(uuid, res.get(0).getId());
+    }
 }


### PR DESCRIPTION
## Summary
- allow the filter lexer to treat hyphenated identifiers as a single token so UUID-style values no longer trigger numeric parsing
- add a regression test that exercises querying by an unquoted hyphenated identifier

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d992282994832dae78d09fdb1d10cc